### PR TITLE
Add Id condition to CreateOrUpdateAttributes

### DIFF
--- a/Extensions/Use SQL Server/Extension.cs
+++ b/Extensions/Use SQL Server/Extension.cs
@@ -180,7 +180,7 @@ class SqlServerTransactor : Transactor, INotifyPropertyChanged, INotifyPropertyC
                 using (var cmd = conn.CreateCommand())
                 {
                     var tablePrefix = kv.Value.IsEnumeration ? "ListValue" : "Text";
-                    cmd.CommandText = $"IF EXISTS (SELECT Id FROM {tablePrefix}Properties) UPDATE {tablePrefix}Properties SET Name = @name, Notes = @notes ELSE INSERT {tablePrefix}Properties (Id, Name, Notes) VALUES (@id, @name, @notes)";
+                    cmd.CommandText = $"IF EXISTS (SELECT Id FROM {tablePrefix}Properties where Id = @id) UPDATE {tablePrefix}Properties SET Name = @name, Notes = @notes where Id = @Id ELSE INSERT {tablePrefix}Properties (Id, Name, Notes) VALUES (@id, @name, @notes)";
                     cmd.Parameters.AddWithValue("@id", kv.Key);
                     cmd.Parameters.AddWithValue("@name", kv.Value.Name);
                     cmd.Parameters.AddWithValue("@notes", (object)kv.Value.Notes ?? DBNull.Value);


### PR DESCRIPTION
A WHERE check is needed in the CreateOrUpdateAttributes sql to update the proper property row. Without it, it would update all rows in the table.